### PR TITLE
feat: full-bleed hero background, refined More Works cards, team photo

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -43,7 +43,7 @@
           </div>
           <div class="grid gap-5">
             <div class="overflow-hidden rounded-[2rem] border border-white/10 shadow-soft reveal" data-reveal>
-              <img src="https://github.com/user-attachments/assets/84ce4c93-fcb5-440a-95a8-0fe036529b57" alt="프러쉬 스튜디오 팀 단체 사진" class="h-full w-full object-cover">
+              <img src="Images/5인%20단체사진_프러쉬.png" alt="프러쉬 스튜디오 팀 단체 사진" class="h-full w-full object-cover">
             </div>
             <div class="grid gap-5 sm:grid-cols-2">
               <article class="contact-card glass rounded-[2rem] p-6 shadow-soft reveal" data-reveal>

--- a/index.html
+++ b/index.html
@@ -25,16 +25,16 @@
   <div id="site-header"></div>
 
   <main>
-    <section class="relative overflow-hidden px-4 pb-20 pt-32 sm:px-6 sm:pb-24 sm:pt-36 lg:px-8 lg:pb-28 lg:pt-40">
+    <section class="hero-section relative overflow-hidden px-4 pb-20 pt-32 sm:px-6 sm:pb-24 sm:pt-36 lg:px-8 lg:pb-28 lg:pt-40">
       <div class="absolute inset-0 bg-grid hero-grid opacity-20"></div>
-      <div class="relative mx-auto max-w-7xl">
+      <div class="hero-backdrop hero-backdrop--full" id="stacked-panels-scene">
+        <div class="hero-noise pointer-events-none absolute inset-0 z-[1] opacity-[0.08]"></div>
+        <div class="stacked-panels-stage absolute inset-0 z-[1]">
+          <div class="stacked-panels-scene" id="stacked-panels-container"></div>
+        </div>
+      </div>
+      <div class="relative z-10 mx-auto max-w-7xl">
         <div class="hero-stage hero-stage-home">
-          <div class="hero-backdrop" id="stacked-panels-scene">
-            <div class="hero-noise pointer-events-none absolute inset-0 z-[1] opacity-[0.08]"></div>
-            <div class="stacked-panels-stage absolute inset-0 z-[1]">
-              <div class="stacked-panels-scene" id="stacked-panels-container"></div>
-            </div>
-          </div>
           <div class="hero-surface">
             <div class="hero-content-shell hero-content-shell--center px-6 py-8 sm:px-10 lg:px-16">
               <div class="hero-layout">
@@ -99,32 +99,44 @@
         </div>
         <div class="grid gap-5 sm:grid-cols-2 lg:grid-cols-4">
           <a href="vertical.html" class="more-card group reveal" data-reveal>
-            <span class="more-card__icon"><i class="fas fa-mobile-screen-button"></i></span>
-            <p class="more-card__eyebrow">More works</p>
-            <h3 class="more-card__title">세로형</h3>
-            <p class="more-card__desc">숏폼 트렌드에 맞춘 세로형 작업들을 한 번에 더 살펴보세요.</p>
-            <span class="more-card__cta">바로가기 <i class="fas fa-arrow-right"></i></span>
+            <div class="more-card__media more-card__media--vertical">
+              <span class="more-card__icon"><i class="fas fa-mobile-screen-button"></i></span>
+              <h3 class="more-card__title">세로형</h3>
+            </div>
+            <div class="more-card__body">
+              <p class="more-card__desc">숏폼 트렌드에 맞춘 세로형 작업들을 한 번에 더 살펴보세요.</p>
+              <span class="more-card__cta">바로가기 <i class="fas fa-arrow-right"></i></span>
+            </div>
           </a>
           <a href="ads.html" class="more-card group reveal" data-reveal>
-            <span class="more-card__icon"><i class="fas fa-bullhorn"></i></span>
-            <p class="more-card__eyebrow">More works</p>
-            <h3 class="more-card__title">광고</h3>
-            <p class="more-card__desc">TVC부터 유튜브, 매장, 옥외 광고까지 광고 작업들을 모아두었습니다.</p>
-            <span class="more-card__cta">바로가기 <i class="fas fa-arrow-right"></i></span>
+            <div class="more-card__media more-card__media--ads">
+              <span class="more-card__icon"><i class="fas fa-bullhorn"></i></span>
+              <h3 class="more-card__title">광고</h3>
+            </div>
+            <div class="more-card__body">
+              <p class="more-card__desc">TVC부터 유튜브, 매장, 옥외 광고까지 광고 작업들을 모아두었습니다.</p>
+              <span class="more-card__cta">바로가기 <i class="fas fa-arrow-right"></i></span>
+            </div>
           </a>
           <a href="others.html" class="more-card group reveal" data-reveal>
-            <span class="more-card__icon"><i class="fas fa-clapperboard"></i></span>
-            <p class="more-card__eyebrow">More works</p>
-            <h3 class="more-card__title">기타 영상</h3>
-            <p class="more-card__desc">이벤트, 행사, 기술 설명, 제품 영상 중심 포트폴리오를 확인할 수 있습니다.</p>
-            <span class="more-card__cta">바로가기 <i class="fas fa-arrow-right"></i></span>
+            <div class="more-card__media more-card__media--others">
+              <span class="more-card__icon"><i class="fas fa-clapperboard"></i></span>
+              <h3 class="more-card__title">기타 영상</h3>
+            </div>
+            <div class="more-card__body">
+              <p class="more-card__desc">이벤트, 행사, 기술 설명, 제품 영상 중심 포트폴리오를 확인할 수 있습니다.</p>
+              <span class="more-card__cta">바로가기 <i class="fas fa-arrow-right"></i></span>
+            </div>
           </a>
-          <a href="contact.html" class="more-card more-card--accent group reveal" data-reveal>
-            <span class="more-card__icon"><i class="fas fa-paper-plane"></i></span>
-            <p class="more-card__eyebrow">Contact</p>
-            <h3 class="more-card__title">문의하기</h3>
-            <p class="more-card__desc">프로젝트 목적과 희망 포맷만 알려주시면 빠르게 상담을 이어갑니다.</p>
-            <span class="more-card__cta">상담 시작 <i class="fas fa-arrow-right"></i></span>
+          <a href="contact.html" class="more-card group reveal" data-reveal>
+            <div class="more-card__media more-card__media--contact">
+              <span class="more-card__icon"><i class="fas fa-paper-plane"></i></span>
+              <h3 class="more-card__title">문의하기</h3>
+            </div>
+            <div class="more-card__body">
+              <p class="more-card__desc">프로젝트 목적과 희망 포맷만 알려주시면 빠르게 상담을 이어갑니다.</p>
+              <span class="more-card__cta more-card__cta--btn">상담 시작하기 <span class="more-card__cta-btn"><i class="fas fa-arrow-right"></i></span></span>
+            </div>
           </a>
         </div>
       </div>

--- a/scripts/site.js
+++ b/scripts/site.js
@@ -1,5 +1,6 @@
 window.FrushSite = (() => {
   const KAKAO_URL = 'https://open.kakao.com/me/frush';
+  const TEAM_PHOTO_URL = 'Images/5인 단체사진_프러쉬.png';
   const PANEL_COUNT = 18;
   const PANEL_IMAGES = [
     'https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=600&q=80',
@@ -70,13 +71,13 @@ window.FrushSite = (() => {
   ];
 
   const awards = [
-    { year: '2025.10', title: '제1회 서울 국제 AI 필름 페스타 농심 광고 부문 대상', org: 'SGAFF' },
+    { year: '2024.11', title: 'NH 애그테크 청년 창업 캠퍼스 SEED 우수상', org: 'NH 애그테크 청년 창업 캠퍼스' },
+    { year: '2025.01', title: '서울대학교 CALS 창업경진대회 대상', org: '서울대학교' },
     { year: '2025.07', title: 'K-AI 콘텐츠 공모전 장려상', org: 'KT그룹희망나눔재단' },
+    { year: '2025.10', title: '제1회 서울 국제 AI 필름 페스타 농심 광고 부문 대상', org: 'SGAFF' },
     { year: '2025.12', title: '대전 AI영상 콘텐츠 공모전 자유형식 부문 우수상', org: '대전정보문화산업진흥원' },
     { year: '2025.12', title: '대한민국 인도적 지원 AI 홍보 공모전 장려상', org: '한국국제협력단' },
-    { year: '2025', title: '농림축산식품부 장관상 수상', org: '농림축산식품부' },
-    { year: '2024', title: '서울대학교 CALS 창업경진대회 대상', org: '서울대학교' },
-    { year: '2024', title: 'NH 애그테크 청년 창업 캠퍼스 SEED 우수상', org: 'NH 애그테크 청년 창업 캠퍼스' }
+    { year: '2025.12', title: '농림축산식품부 장관상 수상', org: '농림축산식품부' }
   ];
 
   const works = [
@@ -468,15 +469,8 @@ window.FrushSite = (() => {
           <p class="text-sm font-semibold uppercase tracking-[0.28em] text-brand-main">Why Frush</p>
           <h2 class="mt-4 text-3xl font-semibold leading-[1.18] text-white sm:text-[2.4rem]">전략과 실행, 그리고 신뢰를<br class="hidden sm:block"> 한 팀으로 연결합니다</h2>
           <p class="mt-5 max-w-xl text-sm leading-7 text-white/70 sm:text-base">서울대 출신 대표, PD 출신 기획자, 전문성 있는 영상 작업자 팀이 함께 브랜드 목적을 정리하고 결과물까지 밀도 있게 완성합니다.</p>
-          <div class="strength-point-list mt-8">
-            <div class="strength-point-item">
-              <span class="strength-point-item__label">Strategy</span>
-              <p>초기 상담에서 브랜드 목적과 메시지를 먼저 정리합니다.</p>
-            </div>
-            <div class="strength-point-item">
-              <span class="strength-point-item__label">Production</span>
-              <p>기획, 촬영, 편집까지 필요한 제작 흐름을 한 팀으로 이어갑니다.</p>
-            </div>
+          <div class="team-photo-frame mt-8 overflow-hidden rounded-[1.75rem]">
+            <img src="${assetPath(TEAM_PHOTO_URL)}" alt="프러쉬 스튜디오 팀 단체 사진" class="h-full w-full object-cover">
           </div>
           <div class="strength-stat-row mt-auto pt-8">
             ${stats.map((stat) => `

--- a/styles/site.css
+++ b/styles/site.css
@@ -77,18 +77,6 @@ body {
   padding: 1rem 0 3rem;
 }
 
-.hero-stage-home::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background:
-   radial-gradient(circle at 50% 22%, rgba(16, 185, 129, 0.24), transparent 24%),
-   radial-gradient(circle at 63% 26%, rgba(245, 158, 11, 0.12), transparent 20%),
-   radial-gradient(circle at 36% 30%, rgba(59, 130, 246, 0.14), transparent 22%),
-   linear-gradient(180deg, rgba(7, 17, 30, 0.82) 0%, rgba(7, 17, 30, 0.4) 44%, rgba(7, 17, 30, 0.14) 100%);
-  pointer-events: none;
-}
-
 .hero-surface {
   position: relative;
   min-height: calc(100vh - 10rem);
@@ -110,6 +98,11 @@ body {
   position: absolute;
   inset: 0;
   overflow: hidden;
+}
+
+/* Full-bleed variant: the moving arch spans the whole hero section. */
+.hero-backdrop--full {
+  z-index: 0;
 }
 
 .hero-backdrop::before {
@@ -629,6 +622,29 @@ body {
   color: var(--brand-light);
 }
 
+.team-photo-frame {
+  position: relative;
+  flex: 1;
+  min-height: 16rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 24px 60px rgba(2, 6, 23, 0.28);
+}
+
+.team-photo-frame img {
+  position: absolute;
+  inset: 0;
+  height: 100%;
+  width: 100%;
+  object-fit: cover;
+}
+
+.team-photo-frame::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0) 45%, rgba(7, 17, 30, 0.22) 100%);
+}
+
 .strength-stat-row {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
@@ -666,65 +682,107 @@ body {
   display: flex;
   flex-direction: column;
   height: 100%;
-  border-radius: 1.75rem;
-  border: 1px solid rgba(15, 23, 42, 0.07);
-  background: rgba(255, 255, 255, 0.92);
-  padding: 1.75rem;
-  backdrop-filter: blur(12px);
-  box-shadow: 0 18px 44px rgba(15, 23, 42, 0.06);
-  transition: transform 0.4s ease, box-shadow 0.4s ease, border-color 0.4s ease;
+  overflow: hidden;
+  border-radius: 1.85rem;
+  background: #ffffff;
+  box-shadow: 0 18px 44px rgba(15, 23, 42, 0.07);
+  transition: transform 0.45s ease, box-shadow 0.45s ease;
 }
 
 .more-card:hover {
-  transform: translateY(-8px);
-  border-color: rgba(16, 185, 129, 0.35);
-  box-shadow: 0 30px 64px rgba(15, 23, 42, 0.14);
+  transform: translateY(-10px);
+  box-shadow: 0 34px 70px rgba(15, 23, 42, 0.16);
+}
+
+.more-card__media {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  min-height: 13.5rem;
+  padding: 1.5rem;
+  overflow: hidden;
+  color: #ffffff;
+}
+
+.more-card__media::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(2, 8, 14, 0) 35%, rgba(2, 8, 14, 0.45) 100%);
+}
+
+.more-card__media--vertical {
+  background:
+    radial-gradient(circle at 78% 18%, rgba(110, 249, 205, 0.35), transparent 55%),
+    linear-gradient(155deg, #0f4a37 0%, #0a2a20 100%);
+}
+
+.more-card__media--ads {
+  background:
+    radial-gradient(circle at 80% 16%, rgba(255, 255, 255, 0.28), transparent 52%),
+    linear-gradient(155deg, #7ba996 0%, #4f7d68 100%);
+}
+
+.more-card__media--others {
+  background:
+    radial-gradient(circle at 80% 16%, rgba(255, 255, 255, 0.22), transparent 52%),
+    linear-gradient(155deg, #79858f 0%, #424d59 100%);
+}
+
+.more-card__media--contact {
+  background:
+    radial-gradient(circle at 78% 18%, rgba(110, 249, 205, 0.32), transparent 55%),
+    linear-gradient(155deg, #10583a 0%, #06311f 100%);
 }
 
 .more-card__icon {
+  position: relative;
+  z-index: 1;
   display: inline-flex;
-  height: 3rem;
-  width: 3rem;
+  height: 2.85rem;
+  width: 2.85rem;
   align-items: center;
   justify-content: center;
-  border-radius: 1rem;
-  background: var(--brand-light);
-  color: var(--brand-dark);
-  font-size: 1.1rem;
-  transition: background 0.4s ease, color 0.4s ease;
-}
-
-.more-card__eyebrow {
-  margin-top: 1.4rem;
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.22em;
-  text-transform: uppercase;
-  color: var(--brand-main);
+  border-radius: 9999px;
+  background: rgba(255, 255, 255, 0.16);
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  color: #ffffff;
+  font-size: 1.05rem;
+  backdrop-filter: blur(6px);
 }
 
 .more-card__title {
-  margin-top: 0.6rem;
-  font-size: 1.4rem;
-  font-weight: 600;
-  color: var(--brand-text);
+  position: relative;
+  z-index: 1;
+  margin-top: 2.4rem;
+  font-size: 1.85rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: #ffffff;
+}
+
+.more-card__body {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  padding: 1.6rem 1.6rem 1.75rem;
 }
 
 .more-card__desc {
-  margin-top: 0.7rem;
-  font-size: 0.875rem;
-  line-height: 1.65;
+  font-size: 0.9rem;
+  line-height: 1.7;
   color: #64748b;
 }
 
 .more-card__cta {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.55rem;
   margin-top: auto;
-  padding-top: 1.5rem;
-  font-size: 0.85rem;
-  font-weight: 600;
+  padding-top: 1.6rem;
+  font-size: 0.9rem;
+  font-weight: 700;
   color: var(--brand-dark);
 }
 
@@ -736,33 +794,27 @@ body {
   transform: translateX(4px);
 }
 
-.more-card--accent {
-  border-color: rgba(16, 185, 129, 0.28);
-  background:
-    radial-gradient(circle at top right, rgba(16, 185, 129, 0.16), transparent 60%),
-    linear-gradient(160deg, rgba(6, 78, 59, 0.97), rgba(8, 26, 42, 0.97));
-  box-shadow: 0 24px 54px rgba(6, 78, 59, 0.24);
+.more-card__cta--btn {
+  justify-content: space-between;
+  width: 100%;
 }
 
-.more-card--accent .more-card__icon {
-  background: rgba(255, 255, 255, 0.12);
+.more-card__cta-btn {
+  display: inline-flex;
+  height: 2.5rem;
+  width: 2.5rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  background: var(--brand-dark);
   color: #ffffff;
+  font-size: 0.85rem;
+  transition: transform 0.4s ease, background 0.4s ease;
 }
 
-.more-card--accent .more-card__eyebrow {
-  color: #6ef9cd;
-}
-
-.more-card--accent .more-card__title {
-  color: #ffffff;
-}
-
-.more-card--accent .more-card__desc {
-  color: rgba(255, 255, 255, 0.72);
-}
-
-.more-card--accent .more-card__cta {
-  color: #6ef9cd;
+.more-card:hover .more-card__cta-btn {
+  background: var(--brand-main);
+  transform: translateX(4px);
 }
 
 .video-modal {


### PR DESCRIPTION
- Expand the moving hero arch to span the full hero section instead of being confined to the inner box
- Redesign More Works cards with themed media headers, icon badges, large titles and CTA buttons
- Replace Strategy/Production blocks in the Why Frush card with the team group photo; keep the stat row
- Correct and chronologically sort award dates (NH 2024.11, CALS 2025.01, 농림축산식품부 장관상 2025.12)
- Use the local team group photo on the Contact page


Claude-Session: https://claude.ai/code/session_01C6aaAyh7mvJDoFZciaLSBw