### PR TITLE
feat: redesign category hero sections, center hero arch, contact grid

### DIFF
--- a/ads.html
+++ b/ads.html
@@ -27,22 +27,43 @@
   <main>
     <section class="relative overflow-hidden px-4 pb-20 pt-32 sm:px-6 sm:pt-36 lg:px-8 lg:pb-24 lg:pt-40">
       <div class="mx-auto max-w-7xl">
-        <div class="subpage-hero-shell grid items-center gap-8 p-6 sm:p-8 lg:grid-cols-[0.95fr_1.05fr] lg:p-10">
+        <div class="subpage-hero-shell grid items-center gap-10 p-6 sm:p-8 lg:grid-cols-[0.92fr_1.08fr] lg:p-12">
           <div class="reveal" data-reveal>
-            <p class="text-sm font-semibold uppercase tracking-[0.28em] text-brand-main">Commercial Works</p>
-            <h1 class="mt-4 text-4xl font-semibold leading-[1.06] text-white sm:text-5xl lg:text-6xl">TVC부터 디지털 매체까지<br>광고 문법을 한 화면에 담습니다.</h1>
-            <p class="mt-6 max-w-2xl text-base leading-8 text-white/72 sm:text-lg">프러쉬 스튜디오는 TVC, 유튜브 광고, 매장 광고, 옥외광고까지 다양한 집행 환경을 고려해 기획합니다. 메시지를 선명하게 전달하면서도 브랜드 톤을 지키는 광고 영상을 제작합니다.</p>
-            <div class="hero-cta-row mt-10">
-              <a href="https://open.kakao.com/me/frush" target="_blank" rel="noreferrer" class="hero-cta-button bg-brand-main text-base font-semibold text-white shadow-glow transition hover:bg-brand-dark">문의하기</a>
-              <a href="#portfolio" class="hero-cta-button border border-white/15 bg-white/5 text-base font-semibold text-white transition hover:bg-white/10">포트폴리오 보기</a>
+            <p class="text-sm font-semibold uppercase tracking-[0.32em] text-brand-main">Commercial Works</p>
+            <h1 class="subhero-headline mt-5">광고의 목적과 매체에 맞춰<br>한 화면의 <span class="text-brand-main">설득력</span>을 만듭니다.</h1>
+            <p class="mt-6 max-w-xl text-base leading-8 text-white/70 sm:text-lg">프러쉬 스튜디오는 TVC, 유튜브 광고, 매장 광고, 옥외 광고까지 집행 환경에 맞춰 메시지와 화면 밀도를 설계합니다. 브랜드 톤은 지키고 전달력은 높이는 광고 영상을 제작합니다.</p>
+            <div class="hero-cta-row mt-9">
+              <a href="https://open.kakao.com/me/frush" target="_blank" rel="noreferrer" class="hero-cta-button gap-2 bg-brand-main text-base font-semibold text-white shadow-glow transition hover:bg-brand-dark">광고 영상 문의하기 <i class="fas fa-chevron-right text-xs"></i></a>
+              <a href="#portfolio" class="hero-cta-button gap-2 border border-white/15 bg-white/5 text-base font-semibold text-white transition hover:bg-white/10">광고 포트폴리오 보기 <i class="fas fa-chevron-right text-xs"></i></a>
             </div>
+            <p class="hero-note mt-8"><i class="fas fa-comment-dots"></i>목표와 매체만 알려주셔도 적합한 영상 방향을 제안드립니다.</p>
           </div>
-          <div class="reveal" data-reveal>
-            <p class="mb-3 text-sm font-semibold uppercase tracking-[0.28em] text-brand-light/80">대표 영상</p>
-            <div class="hero-frame h-[420px] sm:h-[520px]" data-parallax="0.06">
-              <video autoplay muted loop playsinline poster="Images/서울우유 광고.png">
-                <source src="Videos/서울우유광고.mp4" type="video/mp4">
-              </video>
+          <div class="ad-stack reveal" data-reveal data-parallax="0.04">
+            <button type="button" class="ad-feature" data-video-title="서울우유 브랜드 광고" data-video-type="local" data-video-src="Videos/서울우유광고.mp4" data-video-poster="Images/서울우유 광고.png">
+              <img class="ad-feature__media" src="Images/서울우유 광고.png" alt="대표 광고 영상">
+              <div class="ad-feature__copy">
+                <p>자연스러운 한 컷으로<br>브랜드의 메시지를 전합니다</p>
+                <span>BRAND COMMERCIAL</span>
+              </div>
+              <span class="play-btn"><i class="fas fa-play"></i></span>
+              <span class="ad-feature__label">TVC · 30sec</span>
+            </button>
+            <div class="ad-thumbs">
+              <a href="#portfolio" class="ad-thumb">
+                <img class="ad-thumb__media" src="Image_Storage/나진국밥_썸네일.png" alt="TVC 광고">
+                <span class="play-btn play-btn--sm"><i class="fas fa-play"></i></span>
+                <span class="ad-thumb__label">TVC</span>
+              </a>
+              <a href="#portfolio" class="ad-thumb">
+                <img class="ad-thumb__media" src="Image_Storage/프러쉬_썸네일.png" alt="YouTube 광고">
+                <span class="play-btn play-btn--sm"><i class="fas fa-play"></i></span>
+                <span class="ad-thumb__label">YouTube</span>
+              </a>
+              <a href="#portfolio" class="ad-thumb">
+                <img class="ad-thumb__media" src="Images/프러쉬매장.png" alt="매장·옥외 광고">
+                <span class="play-btn play-btn--sm"><i class="fas fa-play"></i></span>
+                <span class="ad-thumb__label">매장 / 옥외</span>
+              </a>
             </div>
           </div>
         </div>

--- a/contact.html
+++ b/contact.html
@@ -27,46 +27,46 @@
   <main>
     <section class="px-4 pb-20 pt-32 sm:px-6 sm:pt-36 lg:px-8 lg:pb-24 lg:pt-40">
       <div class="mx-auto max-w-7xl">
-        <div class="subpage-hero-shell grid gap-8 p-6 sm:p-8 lg:grid-cols-[0.92fr_1.08fr] lg:p-10">
-          <div class="reveal" data-reveal>
-            <p class="text-sm font-semibold uppercase tracking-[0.28em] text-brand-main">Contact</p>
-            <h1 class="mt-4 text-4xl font-semibold leading-[1.06] text-white sm:text-5xl lg:text-6xl">프로젝트가 필요할 때<br>가장 빠르게 연결되는 팀.</h1>
-            <p class="mt-6 max-w-2xl text-base leading-8 text-white/72 sm:text-lg">프러쉬 스튜디오는 단체 사진 속 팀 그대로 움직입니다. 서울대 출신 대표, PD 출신 기획자, 전문성 있는 영상 작업자 팀이 함께 제작 목적과 활용 매체에 맞는 방향을 빠르게 제안합니다.</p>
-            <div class="hero-cta-row mt-10">
-              <a href="https://open.kakao.com/me/frush" target="_blank" rel="noreferrer" class="hero-cta-button gap-3 bg-brand-main text-base font-semibold text-white shadow-glow transition hover:bg-brand-dark">
-                문의하기 <i class="fas fa-arrow-up-right-from-square text-sm"></i>
-              </a>
-              <a href="mailto:frush.brand@gmail.com" class="hero-cta-button border border-white/15 bg-white/5 text-base font-semibold text-white transition hover:bg-white/10">
-                메일 보내기
-              </a>
+        <div class="subpage-hero-shell p-6 sm:p-8 lg:p-10">
+          <div class="grid items-center gap-8 lg:grid-cols-[0.92fr_1.08fr]">
+            <div class="reveal" data-reveal>
+              <p class="text-sm font-semibold uppercase tracking-[0.28em] text-brand-main">Contact</p>
+              <h1 class="mt-4 text-4xl font-semibold leading-[1.06] text-white sm:text-5xl lg:text-6xl">프로젝트가 필요할 때<br>가장 빠르게 연결되는 팀.</h1>
+              <p class="mt-6 max-w-2xl text-base leading-8 text-white/72 sm:text-lg">프러쉬 스튜디오는 단체 사진 속 팀 그대로 움직입니다. 서울대 출신 대표, PD 출신 기획자, 전문성 있는 영상 작업자 팀이 함께 제작 목적과 활용 매체에 맞는 방향을 빠르게 제안합니다.</p>
+              <div class="hero-cta-row mt-10">
+                <a href="https://open.kakao.com/me/frush" target="_blank" rel="noreferrer" class="hero-cta-button gap-3 bg-brand-main text-base font-semibold text-white shadow-glow transition hover:bg-brand-dark">
+                  문의하기 <i class="fas fa-arrow-up-right-from-square text-sm"></i>
+                </a>
+                <a href="mailto:frush.brand@gmail.com" class="hero-cta-button border border-white/15 bg-white/5 text-base font-semibold text-white transition hover:bg-white/10">
+                  메일 보내기
+                </a>
+              </div>
             </div>
-          </div>
-          <div class="grid gap-5">
             <div class="overflow-hidden rounded-[2rem] border border-white/10 shadow-soft reveal" data-reveal>
               <img src="Images/5인%20단체사진_프러쉬.png" alt="프러쉬 스튜디오 팀 단체 사진" class="h-full w-full object-cover">
             </div>
-            <div class="grid gap-5 sm:grid-cols-2">
-              <article class="contact-card glass rounded-[2rem] p-6 shadow-soft reveal" data-reveal>
-                <p class="text-sm font-semibold uppercase tracking-[0.22em] text-brand-main">Response</p>
-                <h2 class="mt-4 text-2xl font-semibold text-white">빠른 커뮤니케이션</h2>
-                <p class="mt-3 text-sm leading-6 text-white/70">필요한 포맷과 목적을 정리해 바로 대화할 수 있도록 설계했습니다.</p>
-              </article>
-              <article class="contact-card glass rounded-[2rem] p-6 shadow-soft reveal" data-reveal>
-                <p class="text-sm font-semibold uppercase tracking-[0.22em] text-brand-main">Direction</p>
-                <h2 class="mt-4 text-2xl font-semibold text-white">브랜드에 맞는 제안</h2>
-                <p class="mt-3 text-sm leading-6 text-white/70">세로형, 광고, 기타 영상 중 어떤 구성이 맞는지 먼저 정리해드립니다.</p>
-              </article>
-              <article class="contact-card glass rounded-[2rem] p-6 shadow-soft reveal" data-reveal>
-                <p class="text-sm font-semibold uppercase tracking-[0.22em] text-brand-main">Delivery</p>
-                <h2 class="mt-4 text-2xl font-semibold text-white">실사용 중심 납품</h2>
-                <p class="mt-3 text-sm leading-6 text-white/70">운영 채널에 맞춰 활용 가능한 형식으로 마무리합니다.</p>
-              </article>
-              <article class="contact-card glass rounded-[2rem] p-6 shadow-soft reveal" data-reveal>
-                <p class="text-sm font-semibold uppercase tracking-[0.22em] text-brand-main">Main Email</p>
-                <h2 class="mt-4 break-all text-2xl font-semibold text-white">frush.brand@gmail.com</h2>
-                <p class="mt-3 text-sm leading-6 text-white/70">메일 또는 오픈카톡 중 편한 채널로 문의하실 수 있습니다.</p>
-              </article>
-            </div>
+          </div>
+          <div class="mt-8 grid gap-5 sm:grid-cols-2 lg:grid-cols-4">
+            <article class="contact-card glass flex flex-col rounded-[2rem] p-6 shadow-soft reveal" data-reveal>
+              <p class="text-sm font-semibold uppercase tracking-[0.22em] text-brand-main">Response</p>
+              <h2 class="mt-4 text-2xl font-semibold text-white">빠른 커뮤니케이션</h2>
+              <p class="mt-3 text-sm leading-6 text-white/70">필요한 포맷과 목적을 정리해 바로 대화할 수 있도록 설계했습니다.</p>
+            </article>
+            <article class="contact-card glass flex flex-col rounded-[2rem] p-6 shadow-soft reveal" data-reveal>
+              <p class="text-sm font-semibold uppercase tracking-[0.22em] text-brand-main">Direction</p>
+              <h2 class="mt-4 text-2xl font-semibold text-white">브랜드에 맞는 제안</h2>
+              <p class="mt-3 text-sm leading-6 text-white/70">세로형, 광고, 기타 영상 중 어떤 구성이 맞는지 먼저 정리해드립니다.</p>
+            </article>
+            <article class="contact-card glass flex flex-col rounded-[2rem] p-6 shadow-soft reveal" data-reveal>
+              <p class="text-sm font-semibold uppercase tracking-[0.22em] text-brand-main">Delivery</p>
+              <h2 class="mt-4 text-2xl font-semibold text-white">실사용 중심 납품</h2>
+              <p class="mt-3 text-sm leading-6 text-white/70">운영 채널에 맞춰 활용 가능한 형식으로 마무리합니다.</p>
+            </article>
+            <article class="contact-card glass flex flex-col rounded-[2rem] p-6 shadow-soft reveal" data-reveal>
+              <p class="text-sm font-semibold uppercase tracking-[0.22em] text-brand-main">Main Email</p>
+              <h2 class="mt-4 break-all text-xl font-semibold text-white">frush.brand@gmail.com</h2>
+              <p class="mt-3 text-sm leading-6 text-white/70">메일 또는 오픈카톡 중 편한 채널로 문의하실 수 있습니다.</p>
+            </article>
           </div>
         </div>
       </div>

--- a/others.html
+++ b/others.html
@@ -27,24 +27,37 @@
   <main>
     <section class="relative overflow-hidden px-4 pb-20 pt-32 sm:px-6 sm:pt-36 lg:px-8 lg:pb-24 lg:pt-40">
       <div class="mx-auto max-w-7xl">
-        <div class="subpage-hero-shell grid items-center gap-8 p-6 sm:p-8 lg:grid-cols-[0.95fr_1.05fr] lg:p-10">
+        <div class="subpage-hero-shell grid items-center gap-10 p-6 sm:p-8 lg:grid-cols-[0.95fr_1.05fr] lg:p-12">
           <div class="reveal" data-reveal>
-            <p class="text-sm font-semibold uppercase tracking-[0.28em] text-brand-main">Brand Film & More</p>
-            <h1 class="mt-4 text-4xl font-semibold leading-[1.06] text-white sm:text-5xl lg:text-6xl">행사와 제품, 기술 설명까지<br>목적에 맞는 정보를 영상으로 정리합니다.</h1>
-            <p class="mt-6 max-w-2xl text-base leading-8 text-white/72 sm:text-lg">기타 영상은 이벤트, 행사, 기술 설명, 제품 영상처럼 전달해야 할 정보와 현장감이 분명한 작업이 중심이 됩니다. 프러쉬 스튜디오는 메시지 구조를 먼저 잡고 필요한 무드와 몰입도를 더합니다.</p>
-            <div class="hero-cta-row mt-10">
-              <a href="https://open.kakao.com/me/frush" target="_blank" rel="noreferrer" class="hero-cta-button bg-brand-main text-base font-semibold text-white shadow-glow transition hover:bg-brand-dark">문의하기</a>
-              <a href="#portfolio" class="hero-cta-button border border-white/15 bg-white/5 text-base font-semibold text-white transition hover:bg-white/10">포트폴리오 보기</a>
+            <p class="text-sm font-semibold uppercase tracking-[0.32em] text-brand-main">Brand Film & More</p>
+            <h1 class="subhero-headline mt-5">브랜드의 분위기와 정보를<br><span class="text-brand-main">영상 언어</span>로 정리합니다.</h1>
+            <p class="mt-6 max-w-xl text-base leading-8 text-white/70 sm:text-lg">행사, 제품, 기술 소개, 인터뷰 영상은 전달해야 할 내용과 현장감이 분명해야 합니다. 프러쉬는 메시지 구조를 먼저 잡고 브랜드가 원하는 무드와 정보 밀도를 화면에 담습니다.</p>
+            <div class="tag-row mt-8">
+              <span class="tag-chip"><i class="fas fa-film"></i>브랜드 필름</span>
+              <span class="tag-chip"><i class="fas fa-calendar-day"></i>행사 영상</span>
+              <span class="tag-chip"><i class="fas fa-box-open"></i>제품 소개</span>
+              <span class="tag-chip"><i class="fas fa-microchip"></i>기술 설명</span>
+              <span class="tag-chip"><i class="fas fa-user"></i>인터뷰 영상</span>
+            </div>
+            <div class="hero-cta-row mt-9">
+              <a href="https://open.kakao.com/me/frush" target="_blank" rel="noreferrer" class="hero-cta-button gap-2 bg-brand-main text-base font-semibold text-white shadow-glow transition hover:bg-brand-dark">브랜드 영상 문의하기 <i class="fas fa-chevron-right text-xs"></i></a>
+              <a href="#portfolio" class="hero-cta-button gap-2 border border-white/15 bg-white/5 text-base font-semibold text-white transition hover:bg-white/10">작업 사례 보기 <i class="fas fa-chevron-right text-xs"></i></a>
             </div>
           </div>
-          <div class="reveal" data-reveal>
-            <p class="mb-3 text-sm font-semibold uppercase tracking-[0.28em] text-brand-light/80">대표 영상</p>
-            <div class="hero-frame h-[420px] sm:h-[520px]" data-parallax="0.06">
-              <video autoplay muted loop playsinline poster="Images/공간 로고.png">
-                <source src="Videos/뉴욕공간 레퍼런스_업로드용.mp4" type="video/mp4">
-              </video>
+          <button type="button" class="film-showcase reveal" data-reveal data-parallax="0.04" data-video-title="Frush 브랜드 필름 쇼릴" data-video-type="local" data-video-src="Videos/뉴욕공간 레퍼런스_업로드용.mp4" data-video-poster="Image_Storage/프러쉬_썸네일.png">
+            <img class="film-showcase__media" src="Image_Storage/프러쉬_썸네일.png" alt="브랜드 필름 대표 작업">
+            <span class="film-showcase__eyebrow">SELECTED WORKS</span>
+            <span class="film-showcase__meta">01:28 <span class="play-btn play-btn--sm" style="position:static;transform:none"><i class="fas fa-play"></i></span></span>
+            <div class="film-showcase__caption">
+              <strong>Frush · 공간 브랜드 필름</strong>
+              <span>BRAND FILM</span>
             </div>
-          </div>
+            <div class="film-showcase__nav">
+              <i class="fas fa-chevron-left"></i>
+              <span class="film-showcase__dots"><i class="is-active"></i><i></i><i></i><i></i></span>
+              <i class="fas fa-chevron-right"></i>
+            </div>
+          </button>
         </div>
       </div>
     </section>

--- a/scripts/site.js
+++ b/scripts/site.js
@@ -561,7 +561,9 @@ window.FrushSite = (() => {
         const angle = startAngle + step * index;
         const angleRad = (angle * Math.PI) / 180;
         const x = Math.cos(angleRad) * radius;
-        const y = Math.sin(angleRad) * radius + arcLift;
+        // Push the whole arch down a touch so it sits centred in the hero
+        // (not glued to the very top) while still arching above the headline.
+        const y = Math.sin(angleRad) * radius + arcLift + radius * 0.2;
         const spread = index / Math.max(PANEL_COUNT - 1, 1);
         const centerDistance = Math.abs(spread - 0.5);
 
@@ -595,8 +597,10 @@ window.FrushSite = (() => {
     updatePanels();
     animatePanels();
 
-    // Track the pointer across the whole hero stage so the arch tilts in 3D.
-    const stageRoot = stage.closest('.hero-stage') || stage;
+    // Track the pointer across the whole hero SECTION (content sits above the
+    // backdrop in its own stacking context, so listening on the section is the
+    // only way to catch movement over the centred copy too).
+    const stageRoot = stage.closest('.hero-section') || stage.closest('section') || stage;
     stageRoot.addEventListener('mousemove', (event) => {
       const rect = stageRoot.getBoundingClientRect();
       targetPointerX = ((event.clientX - rect.left) / rect.width - 0.5) * 2;

--- a/styles/site.css
+++ b/styles/site.css
@@ -817,6 +817,476 @@ body {
   transform: translateX(4px);
 }
 
+/* ============ Subpage hero showcases ============ */
+.subhero-headline {
+  font-size: clamp(2.1rem, 4vw, 3.4rem);
+  font-weight: 700;
+  line-height: 1.14;
+  letter-spacing: -0.01em;
+  color: #ffffff;
+}
+
+/* Feature spec boxes (vertical page) */
+.spec-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.75rem;
+}
+
+.spec-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.7rem;
+  border-radius: 1.1rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  padding: 1.15rem 0.6rem;
+  text-align: center;
+}
+
+.spec-item__icon {
+  display: inline-flex;
+  height: 2.4rem;
+  width: 2.4rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  border: 1px solid rgba(16, 185, 129, 0.4);
+  background: rgba(16, 185, 129, 0.08);
+  color: var(--brand-main);
+  font-size: 0.95rem;
+}
+
+.spec-item__label {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.82);
+}
+
+/* Inline tag chips (others page) */
+.tag-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.tag-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(255, 255, 255, 0.04);
+  padding: 0.6rem 1.05rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.84);
+}
+
+.tag-chip i {
+  color: var(--brand-main);
+}
+
+.hero-note {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.hero-note i {
+  color: var(--brand-main);
+}
+
+/* Phone duo (vertical page) */
+.phone-duo {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1rem;
+}
+
+.phone-card {
+  position: relative;
+  aspect-ratio: 9 / 16;
+  overflow: hidden;
+  border-radius: 1.6rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: #0a1620;
+  box-shadow: 0 30px 70px rgba(0, 0, 0, 0.45);
+}
+
+.phone-card--lift {
+  transform: translateY(-1.4rem);
+}
+
+.phone-card__media {
+  position: absolute;
+  inset: 0;
+  height: 100%;
+  width: 100%;
+  object-fit: cover;
+}
+
+.phone-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(2, 8, 14, 0.5) 0%, rgba(2, 8, 14, 0) 24%, rgba(2, 8, 14, 0) 52%, rgba(2, 8, 14, 0.88) 100%);
+}
+
+.phone-card__top,
+.phone-card__actions,
+.phone-card__bottom {
+  position: absolute;
+  z-index: 1;
+  color: #ffffff;
+}
+
+.phone-card__top {
+  top: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.85rem;
+}
+
+.phone-card__avatar {
+  display: inline-flex;
+  height: 1.7rem;
+  width: 1.7rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  background: var(--brand-main);
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.phone-card__id {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.25;
+}
+
+.phone-card__id strong {
+  font-size: 0.72rem;
+}
+
+.phone-card__id span {
+  font-size: 0.62rem;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.phone-card__more {
+  margin-left: auto;
+  font-size: 0.8rem;
+  opacity: 0.85;
+}
+
+.phone-card__actions {
+  right: 0.7rem;
+  bottom: 6rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.95rem;
+  font-size: 0.6rem;
+}
+
+.phone-card__actions span {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.phone-card__actions i {
+  font-size: 0.95rem;
+}
+
+.phone-card__bottom {
+  left: 0;
+  right: 0;
+  bottom: 0;
+  padding: 0.9rem;
+}
+
+.phone-card__bottom p {
+  font-size: 0.72rem;
+  font-weight: 600;
+  line-height: 1.5;
+}
+
+.phone-card__cta {
+  display: inline-block;
+  margin-top: 0.55rem;
+  border-radius: 9999px;
+  background: rgba(255, 255, 255, 0.18);
+  padding: 0.25rem 0.75rem;
+  font-size: 0.62rem;
+}
+
+.phone-card__progress {
+  margin-top: 0.75rem;
+  height: 3px;
+  border-radius: 9999px;
+  background: rgba(255, 255, 255, 0.28);
+  overflow: hidden;
+}
+
+.phone-card__progress span {
+  display: block;
+  height: 100%;
+  width: 30%;
+  background: var(--brand-main);
+}
+
+.phone-card__time {
+  margin-top: 0.4rem;
+  text-align: right;
+  font-size: 0.58rem;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+/* Ads showcase */
+.ad-stack {
+  display: grid;
+  gap: 1rem;
+}
+
+.ad-feature {
+  position: relative;
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  border-radius: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 30px 70px rgba(0, 0, 0, 0.4);
+  cursor: pointer;
+}
+
+.ad-feature__media,
+.ad-thumb__media,
+.film-showcase__media {
+  position: absolute;
+  inset: 0;
+  height: 100%;
+  width: 100%;
+  object-fit: cover;
+}
+
+.ad-feature::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, rgba(2, 8, 14, 0.85) 0%, rgba(2, 8, 14, 0.35) 52%, rgba(2, 8, 14, 0.12) 100%);
+}
+
+.ad-feature__copy {
+  position: absolute;
+  z-index: 1;
+  left: 1.5rem;
+  top: 50%;
+  transform: translateY(-55%);
+  max-width: 58%;
+  color: #ffffff;
+}
+
+.ad-feature__copy p {
+  font-size: clamp(0.95rem, 1.4vw, 1.25rem);
+  font-weight: 600;
+  line-height: 1.5;
+}
+
+.ad-feature__copy span {
+  display: block;
+  margin-top: 0.7rem;
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.ad-feature__label {
+  position: absolute;
+  z-index: 1;
+  left: 1.5rem;
+  bottom: 1.1rem;
+  font-size: 0.74rem;
+  letter-spacing: 0.12em;
+  color: rgba(255, 255, 255, 0.82);
+}
+
+.play-btn {
+  position: absolute;
+  z-index: 2;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: inline-flex;
+  height: 3.4rem;
+  width: 3.4rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  border: 1px solid rgba(255, 255, 255, 0.55);
+  background: rgba(255, 255, 255, 0.18);
+  color: #ffffff;
+  backdrop-filter: blur(6px);
+  transition: transform 0.3s ease, background 0.3s ease;
+}
+
+.ad-feature:hover .play-btn,
+.film-showcase:hover .play-btn {
+  transform: translate(-50%, -50%) scale(1.08);
+  background: rgba(16, 185, 129, 0.6);
+}
+
+.play-btn--sm {
+  height: 2.4rem;
+  width: 2.4rem;
+  font-size: 0.78rem;
+}
+
+.ad-thumbs {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+}
+
+.ad-thumb {
+  position: relative;
+  display: block;
+  aspect-ratio: 4 / 3;
+  overflow: hidden;
+  border-radius: 1.1rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.ad-thumb::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(2, 8, 14, 0) 45%, rgba(2, 8, 14, 0.72) 100%);
+}
+
+.ad-thumb__label {
+  position: absolute;
+  z-index: 1;
+  left: 0.85rem;
+  bottom: 0.75rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #ffffff;
+}
+
+/* Others / brand-film showcase */
+.film-showcase {
+  position: relative;
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 10;
+  overflow: hidden;
+  border-radius: 1.6rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 30px 70px rgba(0, 0, 0, 0.4);
+  cursor: pointer;
+}
+
+.film-showcase::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(2, 8, 14, 0.55) 0%, rgba(2, 8, 14, 0.1) 40%, rgba(2, 8, 14, 0.85) 100%);
+}
+
+.film-showcase__eyebrow {
+  position: absolute;
+  z-index: 1;
+  top: 1.2rem;
+  left: 1.4rem;
+  font-size: 0.74rem;
+  letter-spacing: 0.18em;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.film-showcase__meta {
+  position: absolute;
+  z-index: 1;
+  top: 1.1rem;
+  right: 1.3rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.78rem;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.film-showcase__caption {
+  position: absolute;
+  z-index: 1;
+  left: 1.4rem;
+  bottom: 1.3rem;
+  color: #ffffff;
+}
+
+.film-showcase__caption strong {
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.film-showcase__caption span {
+  display: block;
+  margin-top: 0.3rem;
+  font-size: 0.72rem;
+  letter-spacing: 0.16em;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.film-showcase__nav {
+  position: absolute;
+  z-index: 1;
+  right: 1.3rem;
+  bottom: 1.3rem;
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.film-showcase__dots {
+  display: flex;
+  gap: 0.3rem;
+}
+
+.film-showcase__dots i {
+  display: inline-block;
+  height: 2px;
+  width: 1.1rem;
+  border-radius: 9999px;
+  background: rgba(255, 255, 255, 0.35);
+}
+
+.film-showcase__dots i.is-active {
+  background: var(--brand-main);
+}
+
+@media (max-width: 640px) {
+  .spec-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .ad-thumbs {
+    grid-template-columns: repeat(3, 1fr);
+  }
+  .phone-card--lift {
+    transform: none;
+  }
+}
+
 .video-modal {
   position: fixed;
   inset: 0;

--- a/vertical.html
+++ b/vertical.html
@@ -27,22 +27,66 @@
   <main>
     <section class="relative overflow-hidden px-4 pb-20 pt-32 sm:px-6 sm:pt-36 lg:px-8 lg:pb-24 lg:pt-40">
       <div class="mx-auto max-w-7xl">
-        <div class="subpage-hero-shell grid items-center gap-8 p-6 sm:p-8 lg:grid-cols-[0.95fr_1.05fr] lg:p-10">
+        <div class="subpage-hero-shell grid items-center gap-10 p-6 sm:p-8 lg:grid-cols-[1.05fr_0.95fr] lg:p-12">
           <div class="reveal" data-reveal>
-            <p class="text-sm font-semibold uppercase tracking-[0.28em] text-brand-main">Vertical Works</p>
-            <h1 class="mt-4 text-4xl font-semibold leading-[1.06] text-white sm:text-5xl lg:text-6xl">요즘 숏폼 트렌드에 맞춰<br>브랜드의 첫 1초를 설계합니다.</h1>
-            <p class="mt-6 max-w-2xl text-base leading-8 text-white/72 sm:text-lg">세로형 영상은 빠른 전개와 강한 후킹이 중요한 포맷입니다. 프러쉬 스튜디오는 릴스, 쇼츠, 틱톡처럼 스크롤 속도에 맞는 리듬으로 브랜드 메시지를 자연스럽게 남깁니다.</p>
-            <div class="hero-cta-row mt-10">
-              <a href="https://open.kakao.com/me/frush" target="_blank" rel="noreferrer" class="hero-cta-button bg-brand-main text-base font-semibold text-white shadow-glow transition hover:bg-brand-dark">문의하기</a>
-              <a href="#portfolio" class="hero-cta-button border border-white/15 bg-white/5 text-base font-semibold text-white transition hover:bg-white/10">포트폴리오 보기</a>
+            <p class="text-sm font-semibold uppercase tracking-[0.32em] text-brand-main">Vertical Works</p>
+            <h1 class="subhero-headline mt-5">첫 1초에 멈추게 만들고<br><span class="text-brand-main">끝까지 보게</span> 설계합니다.</h1>
+            <p class="mt-6 max-w-xl text-base leading-8 text-white/70 sm:text-lg">릴스, 쇼츠, 틱톡처럼 빠르게 소비되는 화면에서는 첫 장면의 후킹과 리듬이 성과를 가릅니다. 프러쉬는 브랜드 메시지를 짧은 흐름 안에 자연스럽게 심어 스크롤을 멈추는 세로형 영상을 제작합니다.</p>
+            <div class="hero-cta-row mt-9">
+              <a href="https://open.kakao.com/me/frush" target="_blank" rel="noreferrer" class="hero-cta-button gap-2 bg-brand-main text-base font-semibold text-white shadow-glow transition hover:bg-brand-dark">세로형 영상 문의하기 <i class="fas fa-chevron-right text-xs"></i></a>
+              <a href="#portfolio" class="hero-cta-button gap-2 border border-white/15 bg-white/5 text-base font-semibold text-white transition hover:bg-white/10">세로형 포트폴리오 보기 <i class="fas fa-chevron-right text-xs"></i></a>
+            </div>
+            <div class="spec-grid mt-10">
+              <div class="spec-item"><span class="spec-item__icon"><i class="fas fa-bolt"></i></span><span class="spec-item__label">1초 후킹 설계</span></div>
+              <div class="spec-item"><span class="spec-item__icon"><i class="fas fa-wave-square"></i></span><span class="spec-item__label">리듬 기반 편집</span></div>
+              <div class="spec-item"><span class="spec-item__icon"><i class="fas fa-bullseye"></i></span><span class="spec-item__label">메시지 인젝션</span></div>
+              <div class="spec-item"><span class="spec-item__icon"><i class="fas fa-chart-line"></i></span><span class="spec-item__label">성과 중심 제작</span></div>
             </div>
           </div>
-          <div class="reveal" data-reveal>
-            <p class="mb-3 text-sm font-semibold uppercase tracking-[0.28em] text-brand-light/80">대표 영상</p>
-            <div class="hero-frame h-[420px] sm:h-[520px]" data-parallax="0.06">
-              <video autoplay muted loop playsinline poster="Image_Storage/나진국밥_썸네일.png">
+          <div class="phone-duo reveal" data-reveal data-parallax="0.04">
+            <div class="phone-card phone-card--lift">
+              <video class="phone-card__media" autoplay muted loop playsinline poster="Image_Storage/나진국밥_썸네일.png">
                 <source src="Videos/나진국밥 레퍼런스_업로드용3.mp4" type="video/mp4">
               </video>
+              <div class="phone-card__top">
+                <span class="phone-card__avatar">F</span>
+                <div class="phone-card__id"><strong>FRUSH STUDIO</strong><span>브랜드 필름</span></div>
+                <i class="fas fa-ellipsis-vertical phone-card__more"></i>
+              </div>
+              <div class="phone-card__actions">
+                <span><i class="fas fa-heart"></i>1.2만</span>
+                <span><i class="fas fa-comment"></i>128</span>
+                <span><i class="fas fa-share"></i>342</span>
+                <span><i class="fas fa-ellipsis"></i></span>
+              </div>
+              <div class="phone-card__bottom">
+                <p>본질에 집중한 선택,<br>당신의 루틴이 바뀌는 순간</p>
+                <span class="phone-card__cta">자세히 보기</span>
+                <div class="phone-card__progress"><span></span></div>
+                <div class="phone-card__time">00:04 / 00:15</div>
+              </div>
+            </div>
+            <div class="phone-card">
+              <video class="phone-card__media" autoplay muted loop playsinline poster="Image_Storage/프러쉬_썸네일.png">
+                <source src="Videos/나홀로복싱 레퍼런스_업로드용.mp4" type="video/mp4">
+              </video>
+              <div class="phone-card__top">
+                <span class="phone-card__avatar">F</span>
+                <div class="phone-card__id"><strong>FRUSH STUDIO</strong><span>시네마틱 쇼츠</span></div>
+                <i class="fas fa-ellipsis-vertical phone-card__more"></i>
+              </div>
+              <div class="phone-card__actions">
+                <span><i class="fas fa-heart"></i>1.2만</span>
+                <span><i class="fas fa-comment"></i>128</span>
+                <span><i class="fas fa-share"></i>342</span>
+                <span><i class="fas fa-ellipsis"></i></span>
+              </div>
+              <div class="phone-card__bottom">
+                <p>브랜드의 본질을 영상에 담아<br>기억되는 스토리를 만듭니다</p>
+                <span class="phone-card__cta">자세히 보기</span>
+                <div class="phone-card__progress"><span></span></div>
+                <div class="phone-card__time">00:06 / 00:15</div>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
- Center the home hero arch in the viewport and fix mouse tracking so the 3D tilt responds smoothly to normal cursor movement across the whole section (listener moved to the section; content no longer blocks events)
- Redesign vertical hero with social short phone mockups and feature spec boxes
- Redesign ads hero with a feature commercial card and TVC/YouTube/매장 thumbs
- Redesign others hero with category tag chips and a selected-works showcase
- Lay out the contact info cards in a single row of four


Claude-Session: https://claude.ai/code/session_01C6aaAyh7mvJDoFZciaLSBw