### PR TITLE
feat: working showcase carousel, hero/awards/headline refinements

### DIFF
--- a/ads.html
+++ b/ads.html
@@ -30,7 +30,7 @@
         <div class="subpage-hero-shell grid items-center gap-10 p-6 sm:p-8 lg:grid-cols-[0.92fr_1.08fr] lg:p-12">
           <div class="reveal" data-reveal>
             <p class="text-sm font-semibold uppercase tracking-[0.32em] text-brand-main">Commercial Works</p>
-            <h1 class="subhero-headline mt-5">광고의 목적과 매체에 맞춰<br>한 화면의 <span class="text-brand-main">설득력</span>을 만듭니다.</h1>
+            <h1 class="subhero-headline mt-5">광고의 목적과<br>매체에 맞춰<br>한 화면의 <span class="text-brand-main">설득력</span>을 만듭니다.</h1>
             <p class="mt-6 max-w-xl text-base leading-8 text-white/70 sm:text-lg">프러쉬 스튜디오는 TVC, 유튜브 광고, 매장 광고, 옥외 광고까지 집행 환경에 맞춰 메시지와 화면 밀도를 설계합니다. 브랜드 톤은 지키고 전달력은 높이는 광고 영상을 제작합니다.</p>
             <div class="hero-cta-row mt-9">
               <a href="https://open.kakao.com/me/frush" target="_blank" rel="noreferrer" class="hero-cta-button gap-2 bg-brand-main text-base font-semibold text-white shadow-glow transition hover:bg-brand-dark">광고 영상 문의하기 <i class="fas fa-chevron-right text-xs"></i></a>

--- a/others.html
+++ b/others.html
@@ -33,7 +33,6 @@
             <h1 class="subhero-headline mt-5">브랜드의 분위기와 정보를<br><span class="text-brand-main">영상 언어</span>로 정리합니다.</h1>
             <p class="mt-6 max-w-xl text-base leading-8 text-white/70 sm:text-lg">행사, 제품, 기술 소개, 인터뷰 영상은 전달해야 할 내용과 현장감이 분명해야 합니다. 프러쉬는 메시지 구조를 먼저 잡고 브랜드가 원하는 무드와 정보 밀도를 화면에 담습니다.</p>
             <div class="tag-row mt-8">
-              <span class="tag-chip"><i class="fas fa-film"></i>브랜드 필름</span>
               <span class="tag-chip"><i class="fas fa-calendar-day"></i>행사 영상</span>
               <span class="tag-chip"><i class="fas fa-box-open"></i>제품 소개</span>
               <span class="tag-chip"><i class="fas fa-microchip"></i>기술 설명</span>
@@ -44,20 +43,28 @@
               <a href="#portfolio" class="hero-cta-button gap-2 border border-white/15 bg-white/5 text-base font-semibold text-white transition hover:bg-white/10">작업 사례 보기 <i class="fas fa-chevron-right text-xs"></i></a>
             </div>
           </div>
-          <button type="button" class="film-showcase reveal" data-reveal data-parallax="0.04" data-video-title="Frush 브랜드 필름 쇼릴" data-video-type="local" data-video-src="Videos/뉴욕공간 레퍼런스_업로드용.mp4" data-video-poster="Image_Storage/프러쉬_썸네일.png">
-            <img class="film-showcase__media" src="Image_Storage/프러쉬_썸네일.png" alt="브랜드 필름 대표 작업">
+          <div class="film-showcase reveal" data-reveal data-parallax="0.04" data-showcase
+               data-slides='[
+                 {"img":"Image_Storage/프러쉬_썸네일.png","video":"Videos/프러쉬_업로드용.mp4","title":"Frush · 브랜드 쇼릴","tag":"BRAND FILM","time":"01:28"},
+                 {"img":"Images/프러쉬매장.png","video":"Videos/뉴욕공간 레퍼런스_업로드용.mp4","title":"공간 · 브랜드 필름","tag":"SPACE FILM","time":"00:46"},
+                 {"img":"Image_Storage/나진국밥_썸네일.png","video":"Videos/정담 레퍼런스_업로드용.mp4","title":"정담 · 행사 영상","tag":"EVENT FILM","time":"00:38"},
+                 {"img":"Images/서울우유 광고.png","video":"Videos/우곱집 레퍼런스_업로드용.mp4","title":"우곱집 · 제품 영상","tag":"PRODUCT FILM","time":"00:52"}
+               ]'>
+            <img class="film-showcase__media" data-showcase-media src="Image_Storage/프러쉬_썸네일.png" alt="브랜드 필름 대표 작업">
             <span class="film-showcase__eyebrow">SELECTED WORKS</span>
-            <span class="film-showcase__meta">01:28 <span class="play-btn play-btn--sm" style="position:static;transform:none"><i class="fas fa-play"></i></span></span>
+            <span class="film-showcase__meta"><span data-showcase-time>01:28</span>
+              <button type="button" class="play-btn play-btn--sm film-showcase__play" data-showcase-play data-video-type="local" data-video-src="Videos/프러쉬_업로드용.mp4" data-video-poster="Image_Storage/프러쉬_썸네일.png" data-video-title="Frush · 브랜드 쇼릴" aria-label="영상 재생"><i class="fas fa-play"></i></button>
+            </span>
             <div class="film-showcase__caption">
-              <strong>Frush · 공간 브랜드 필름</strong>
-              <span>BRAND FILM</span>
+              <strong data-showcase-title>Frush · 브랜드 쇼릴</strong>
+              <span data-showcase-tag>BRAND FILM</span>
             </div>
             <div class="film-showcase__nav">
-              <i class="fas fa-chevron-left"></i>
-              <span class="film-showcase__dots"><i class="is-active"></i><i></i><i></i><i></i></span>
-              <i class="fas fa-chevron-right"></i>
+              <button type="button" class="film-showcase__arrow" data-showcase-prev aria-label="이전 작업"><i class="fas fa-chevron-left"></i></button>
+              <span class="film-showcase__dots" data-showcase-dots></span>
+              <button type="button" class="film-showcase__arrow" data-showcase-next aria-label="다음 작업"><i class="fas fa-chevron-right"></i></button>
             </div>
-          </button>
+          </div>
         </div>
       </div>
     </section>

--- a/scripts/site.js
+++ b/scripts/site.js
@@ -71,13 +71,13 @@ window.FrushSite = (() => {
   ];
 
   const awards = [
-    { year: '2024.11', title: 'NH 애그테크 청년 창업 캠퍼스 SEED 우수상', org: 'NH 애그테크 청년 창업 캠퍼스' },
-    { year: '2025.01', title: '서울대학교 CALS 창업경진대회 대상', org: '서울대학교' },
-    { year: '2025.07', title: 'K-AI 콘텐츠 공모전 장려상', org: 'KT그룹희망나눔재단' },
-    { year: '2025.10', title: '제1회 서울 국제 AI 필름 페스타 농심 광고 부문 대상', org: 'SGAFF' },
-    { year: '2025.12', title: '대전 AI영상 콘텐츠 공모전 자유형식 부문 우수상', org: '대전정보문화산업진흥원' },
+    { year: '2025.12', title: '농림축산식품부 장관상 수상', org: '농림축산식품부' },
     { year: '2025.12', title: '대한민국 인도적 지원 AI 홍보 공모전 장려상', org: '한국국제협력단' },
-    { year: '2025.12', title: '농림축산식품부 장관상 수상', org: '농림축산식품부' }
+    { year: '2025.12', title: '대전 AI영상 콘텐츠 공모전 자유형식 부문 우수상', org: '대전정보문화산업진흥원' },
+    { year: '2025.10', title: '제1회 서울 국제 AI 필름 페스타 농심 광고 부문 대상', org: 'SGAFF' },
+    { year: '2025.07', title: 'K-AI 콘텐츠 공모전 장려상', org: 'KT그룹희망나눔재단' },
+    { year: '2025.01', title: '서울대학교 CALS 창업경진대회 대상', org: '서울대학교' },
+    { year: '2024.11', title: 'NH 애그테크 청년 창업 캠퍼스 SEED 우수상', org: 'NH 애그테크 청년 창업 캠퍼스' }
   ];
 
   const works = [
@@ -561,9 +561,9 @@ window.FrushSite = (() => {
         const angle = startAngle + step * index;
         const angleRad = (angle * Math.PI) / 180;
         const x = Math.cos(angleRad) * radius;
-        // Push the whole arch down a touch so it sits centred in the hero
-        // (not glued to the very top) while still arching above the headline.
-        const y = Math.sin(angleRad) * radius + arcLift + radius * 0.2;
+        // Push the whole arch down so it sits centred in the hero and the top
+        // cards clear the fixed nav bar instead of being clipped behind it.
+        const y = Math.sin(angleRad) * radius + arcLift + radius * 0.4;
         const spread = index / Math.max(PANEL_COUNT - 1, 1);
         const centerDistance = Math.abs(spread - 0.5);
 
@@ -613,6 +613,64 @@ window.FrushSite = (() => {
     });
 
     window.addEventListener('resize', updatePanels);
+  }
+
+  function setupShowcaseCarousel() {
+    const el = document.querySelector('[data-showcase]');
+    if (!el) return;
+
+    let slides;
+    try {
+      slides = JSON.parse(el.dataset.slides || '[]');
+    } catch (error) {
+      return;
+    }
+    if (!slides.length) return;
+
+    const media = el.querySelector('[data-showcase-media]');
+    const title = el.querySelector('[data-showcase-title]');
+    const tag = el.querySelector('[data-showcase-tag]');
+    const time = el.querySelector('[data-showcase-time]');
+    const play = el.querySelector('[data-showcase-play]');
+    const dotsWrap = el.querySelector('[data-showcase-dots]');
+    const prev = el.querySelector('[data-showcase-prev]');
+    const next = el.querySelector('[data-showcase-next]');
+
+    let index = 0;
+
+    if (dotsWrap) {
+      dotsWrap.innerHTML = slides.map((_, i) => `<i${i === 0 ? ' class="is-active"' : ''}></i>`).join('');
+    }
+    const dots = dotsWrap ? Array.from(dotsWrap.children) : [];
+
+    const render = () => {
+      const slide = slides[index];
+      if (media) {
+        media.src = assetPath(slide.img);
+        media.alt = slide.title || '';
+      }
+      if (title) title.textContent = slide.title || '';
+      if (tag) tag.textContent = slide.tag || '';
+      if (time) time.textContent = slide.time || '';
+      if (play) {
+        play.dataset.videoSrc = assetPath(slide.video);
+        play.dataset.videoPoster = assetPath(slide.img);
+        play.dataset.videoTitle = slide.title || '영상 보기';
+        play.dataset.videoType = 'local';
+      }
+      dots.forEach((dot, i) => dot.classList.toggle('is-active', i === index));
+    };
+
+    const step = (delta) => {
+      index = (index + delta + slides.length) % slides.length;
+      render();
+    };
+
+    if (prev) prev.addEventListener('click', () => step(-1));
+    if (next) next.addEventListener('click', () => step(1));
+    dots.forEach((dot, i) => dot.addEventListener('click', () => { index = i; render(); }));
+
+    render();
   }
 
   function setupRevealObserver() {
@@ -746,6 +804,7 @@ window.FrushSite = (() => {
 
     setupNavbar();
     setupModal();
+    setupShowcaseCarousel();
     setupRevealObserver();
     setupParallax();
     setupStackedPanels();

--- a/styles/site.css
+++ b/styles/site.css
@@ -1247,15 +1247,44 @@ body {
   color: rgba(255, 255, 255, 0.72);
 }
 
+.film-showcase__play {
+  position: static;
+  transform: none;
+}
+
+.film-showcase:hover .film-showcase__play {
+  transform: none;
+  background: rgba(16, 185, 129, 0.6);
+}
+
 .film-showcase__nav {
   position: absolute;
-  z-index: 1;
+  z-index: 2;
   right: 1.3rem;
   bottom: 1.3rem;
   display: flex;
   align-items: center;
   gap: 0.8rem;
   color: rgba(255, 255, 255, 0.8);
+}
+
+.film-showcase__arrow {
+  display: inline-flex;
+  height: 2rem;
+  width: 2rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  background: rgba(255, 255, 255, 0.12);
+  color: #ffffff;
+  font-size: 0.75rem;
+  transition: background 0.3s ease, transform 0.3s ease;
+}
+
+.film-showcase__arrow:hover {
+  background: rgba(16, 185, 129, 0.6);
+  transform: scale(1.08);
 }
 
 .film-showcase__dots {
@@ -1269,6 +1298,7 @@ body {
   width: 1.1rem;
   border-radius: 9999px;
   background: rgba(255, 255, 255, 0.35);
+  cursor: pointer;
 }
 
 .film-showcase__dots i.is-active {


### PR DESCRIPTION
- Make the others-page selected-works arrows functional: real carousel that cycles slides, updates caption/time/dots and the play target
- Remove the '브랜드 필름' chip from the others category tags
- Break the ads headline after '목적과' so '매체에 맞춰' starts a new line
- Lower the home hero arch further so the top cards clear the fixed nav
- Sort awards descending so the most recent sits top-left


Claude-Session: https://claude.ai/code/session_01C6aaAyh7mvJDoFZciaLSBw