### PR TITLE
모바일 파트너 마퀴 번들거림·히어로 중앙 카드 겹침 수정

### DIFF
--- a/scripts/site.js
+++ b/scripts/site.js
@@ -578,7 +578,13 @@ window.FrushSite = (() => {
         const centerDistance = Math.abs(spread - 0.5);
 
         // Each card sits tangent to the arc; subtle per-card parallax on hover.
-        const depth = (0.5 - centerDistance) * 200 - 80;
+        // The scene uses preserve-3d, so stacking is decided by real depth (z),
+        // not z-index. A small directional bias keeps the two apex cards from
+        // sharing the exact same depth — otherwise they z-fight and overlap
+        // messily on touch devices, where there's no pointer tilt to separate
+        // them. This makes one centre card sit cleanly on top.
+        const depthBias = (spread - 0.5) * 60;
+        const depth = (0.5 - centerDistance) * 200 - 80 + depthBias;
         const depthOffset = currentPointerX * (12 + spread * 22);
         const lift = currentPointerY * (14 + (1 - centerDistance) * 16);
         const scale = 0.9 + (1 - centerDistance) * 0.16 + Math.abs(currentPointerY) * 0.02;

--- a/styles/site.css
+++ b/styles/site.css
@@ -575,8 +575,9 @@ body {
   overflow: hidden;
   border-radius: 1.5rem;
   border: 1px solid rgba(226, 232, 240, 0.72);
-  background: rgba(255, 255, 255, 0.72);
-  backdrop-filter: blur(12px);
+  /* Opaque background (no backdrop-filter): a moving backdrop-filter shimmers
+     along the card edges while the marquee scrolls on mobile (iOS Safari). */
+  background: #ffffff;
   box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
 }
 


### PR DESCRIPTION
- 파트너 카드의 backdrop-filter 제거(불투명 배경으로 대체). 마퀴 스크롤 중 움직이는 backdrop-filter가 모바일(iOS Safari)에서 카드 가장자리를 번들거리게 하던 현상 해결
- 히어로 아치 정점 두 카드가 preserve-3d에서 동일 depth로 z-fighting하며 겹쳐 보이던 문제를, depth에 방향성 바이어스를 줘 한 장이 확실히 위 레이어에 오도록 수정(터치 환경에서도 깔끔하게 정렬)


Claude-Session: https://claude.ai/code/session_016azuw8sRu8BWxS1W4rzpRN