### PR TITLE
Swap subpage hero videos to YouTube works

### DIFF
--- a/ads.html
+++ b/ads.html
@@ -39,8 +39,8 @@
             <p class="hero-note mt-8"><i class="fas fa-comment-dots"></i>목표와 매체만 알려주셔도 적합한 영상 방향을 제안드립니다.</p>
           </div>
           <div class="ad-stack reveal" data-reveal data-parallax="0.04">
-            <button type="button" class="ad-feature" data-video-title="서울우유 브랜드 광고" data-video-type="local" data-video-src="Videos/서울우유광고.mp4" data-video-poster="Images/서울우유 광고.png">
-              <img class="ad-feature__media" src="Images/서울우유 광고.png" alt="대표 광고 영상">
+            <button type="button" class="ad-feature" data-video-title="돌핀이 만든 45초의 기적 (30초)" data-video-type="youtube" data-video-src="https://www.youtube.com/embed/xlCSekDfM94?autoplay=1&amp;rel=0" data-video-poster="https://img.youtube.com/vi/xlCSekDfM94/hqdefault.jpg">
+              <img class="ad-feature__media" src="https://img.youtube.com/vi/xlCSekDfM94/hqdefault.jpg" alt="에코텀 · 돌핀이 만든 45초의 기적 30초">
               <div class="ad-feature__copy">
                 <p>자연스러운 한 컷으로<br>브랜드의 메시지를 전합니다</p>
                 <span>BRAND COMMERCIAL</span>
@@ -49,21 +49,21 @@
               <span class="ad-feature__label">TVC · 30sec</span>
             </button>
             <div class="ad-thumbs">
-              <a href="#portfolio" class="ad-thumb">
-                <img class="ad-thumb__media" src="Image_Storage/나진국밥_썸네일.png" alt="TVC 광고">
+              <button type="button" class="ad-thumb" data-video-title="후회없이 참 잘한 선택, 후참잘" data-video-type="youtube" data-video-src="https://www.youtube.com/embed/KOKwG5u83Bs?autoplay=1&amp;rel=0" data-video-poster="https://img.youtube.com/vi/KOKwG5u83Bs/hqdefault.jpg">
+                <img class="ad-thumb__media" src="https://img.youtube.com/vi/KOKwG5u83Bs/hqdefault.jpg" alt="후참잘 브랜드 광고">
                 <span class="play-btn play-btn--sm"><i class="fas fa-play"></i></span>
-                <span class="ad-thumb__label">TVC</span>
-              </a>
-              <a href="#portfolio" class="ad-thumb">
-                <img class="ad-thumb__media" src="Image_Storage/프러쉬_썸네일.png" alt="YouTube 광고">
+                <span class="ad-thumb__label">후참잘</span>
+              </button>
+              <button type="button" class="ad-thumb" data-video-title="공간을 지키는 탈취제" data-video-type="youtube" data-video-src="https://www.youtube.com/embed/6XvkUQwWegI?autoplay=1&amp;rel=0" data-video-poster="https://img.youtube.com/vi/6XvkUQwWegI/hqdefault.jpg">
+                <img class="ad-thumb__media" src="https://img.youtube.com/vi/6XvkUQwWegI/hqdefault.jpg" alt="데오포켓 · 공간을 지키는 탈취제">
                 <span class="play-btn play-btn--sm"><i class="fas fa-play"></i></span>
-                <span class="ad-thumb__label">YouTube</span>
-              </a>
-              <a href="#portfolio" class="ad-thumb">
-                <img class="ad-thumb__media" src="Images/프러쉬매장.png" alt="매장·옥외 광고">
+                <span class="ad-thumb__label">탈취제</span>
+              </button>
+              <button type="button" class="ad-thumb" data-video-title="신라면 왕국" data-video-type="youtube" data-video-src="https://www.youtube.com/embed/cN7fM_m0TAM?autoplay=1&amp;rel=0" data-video-poster="https://img.youtube.com/vi/cN7fM_m0TAM/hqdefault.jpg">
+                <img class="ad-thumb__media" src="https://img.youtube.com/vi/cN7fM_m0TAM/hqdefault.jpg" alt="농심 · 신라면 왕국">
                 <span class="play-btn play-btn--sm"><i class="fas fa-play"></i></span>
-                <span class="ad-thumb__label">매장 / 옥외</span>
-              </a>
+                <span class="ad-thumb__label">신라면</span>
+              </button>
             </div>
           </div>
         </div>

--- a/others.html
+++ b/others.html
@@ -45,19 +45,19 @@
           </div>
           <div class="film-showcase reveal" data-reveal data-parallax="0.04" data-showcase
                data-slides='[
-                 {"img":"Image_Storage/프러쉬_썸네일.png","video":"Videos/프러쉬_업로드용.mp4","title":"Frush · 브랜드 쇼릴","tag":"BRAND FILM","time":"01:28"},
-                 {"img":"Images/프러쉬매장.png","video":"Videos/뉴욕공간 레퍼런스_업로드용.mp4","title":"공간 · 브랜드 필름","tag":"SPACE FILM","time":"00:46"},
-                 {"img":"Image_Storage/나진국밥_썸네일.png","video":"Videos/정담 레퍼런스_업로드용.mp4","title":"정담 · 행사 영상","tag":"EVENT FILM","time":"00:38"},
-                 {"img":"Images/서울우유 광고.png","video":"Videos/우곱집 레퍼런스_업로드용.mp4","title":"우곱집 · 제품 영상","tag":"PRODUCT FILM","time":"00:52"}
+                 {"youtubeUrl":"https://youtu.be/eySPQtTqLMI","title":"라이프 타임 · 예고편","tag":"TRAILER","time":""},
+                 {"youtubeUrl":"https://youtu.be/cSMN1ACu6Qc","title":"PROMPT · 블랙 코미디","tag":"SHORT FILM","time":""},
+                 {"youtubeUrl":"https://youtu.be/7tyImYjmPE0","title":"안재욱 팬미팅 · 상하이","tag":"EVENT FILM","time":""},
+                 {"youtubeUrl":"https://youtu.be/exmbL6na9Z8","title":"PREMIER POKER LEAGUE","tag":"STADIUM","time":""}
                ]'>
-            <img class="film-showcase__media" data-showcase-media src="Image_Storage/프러쉬_썸네일.png" alt="브랜드 필름 대표 작업">
+            <img class="film-showcase__media" data-showcase-media src="https://img.youtube.com/vi/eySPQtTqLMI/hqdefault.jpg" alt="기타 영상 대표 작업">
             <span class="film-showcase__eyebrow">SELECTED WORKS</span>
-            <span class="film-showcase__meta"><span data-showcase-time>01:28</span>
-              <button type="button" class="play-btn play-btn--sm film-showcase__play" data-showcase-play data-video-type="local" data-video-src="Videos/프러쉬_업로드용.mp4" data-video-poster="Image_Storage/프러쉬_썸네일.png" data-video-title="Frush · 브랜드 쇼릴" aria-label="영상 재생"><i class="fas fa-play"></i></button>
+            <span class="film-showcase__meta"><span data-showcase-time></span>
+              <button type="button" class="play-btn play-btn--sm film-showcase__play" data-showcase-play data-video-type="youtube" data-video-src="https://www.youtube.com/embed/eySPQtTqLMI?autoplay=1&amp;rel=0" data-video-poster="https://img.youtube.com/vi/eySPQtTqLMI/hqdefault.jpg" data-video-title="라이프 타임 · 예고편" aria-label="영상 재생"><i class="fas fa-play"></i></button>
             </span>
             <div class="film-showcase__caption">
-              <strong data-showcase-title>Frush · 브랜드 쇼릴</strong>
-              <span data-showcase-tag>BRAND FILM</span>
+              <strong data-showcase-title>라이프 타임 · 예고편</strong>
+              <span data-showcase-tag>TRAILER</span>
             </div>
             <div class="film-showcase__nav">
               <button type="button" class="film-showcase__arrow" data-showcase-prev aria-label="이전 작업"><i class="fas fa-chevron-left"></i></button>

--- a/scripts/site.js
+++ b/scripts/site.js
@@ -1172,18 +1172,20 @@ window.FrushSite = (() => {
 
     const render = () => {
       const slide = slides[index];
+      const isYoutube = Boolean(slide.youtubeUrl);
+      const poster = slide.img ? assetPath(slide.img) : getYoutubePoster(slide.youtubeUrl);
       if (media) {
-        media.src = assetPath(slide.img);
+        media.src = poster;
         media.alt = slide.title || '';
       }
       if (title) title.textContent = slide.title || '';
       if (tag) tag.textContent = slide.tag || '';
       if (time) time.textContent = slide.time || '';
       if (play) {
-        play.dataset.videoSrc = assetPath(slide.video);
-        play.dataset.videoPoster = assetPath(slide.img);
+        play.dataset.videoSrc = isYoutube ? getYoutubeEmbedUrl(slide.youtubeUrl) : assetPath(slide.video);
+        play.dataset.videoPoster = poster;
         play.dataset.videoTitle = slide.title || '영상 보기';
-        play.dataset.videoType = 'local';
+        play.dataset.videoType = isYoutube ? 'youtube' : 'local';
       }
       dots.forEach((dot, i) => dot.classList.toggle('is-active', i === index));
     };

--- a/styles/site.css
+++ b/styles/site.css
@@ -1231,6 +1231,13 @@ body {
 .ad-thumb {
   position: relative;
   display: block;
+  width: 100%;
+  padding: 0;
+  margin: 0;
+  background: none;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
   aspect-ratio: 4 / 3;
   overflow: hidden;
   border-radius: 1.1rem;

--- a/vertical.html
+++ b/vertical.html
@@ -45,9 +45,7 @@
           </div>
           <div class="phone-duo reveal" data-reveal data-parallax="0.04">
             <div class="phone-card phone-card--lift">
-              <video class="phone-card__media" autoplay muted loop playsinline poster="Image_Storage/나진국밥_썸네일.png">
-                <source src="Videos/나진국밥 레퍼런스_업로드용3.mp4" type="video/mp4">
-              </video>
+              <iframe class="phone-card__media" src="https://www.youtube.com/embed/bFllIytaWss?autoplay=1&amp;mute=1&amp;loop=1&amp;playlist=bFllIytaWss&amp;controls=0&amp;modestbranding=1&amp;playsinline=1&amp;rel=0" title="COCX · KOREA TRAVEL, BUSAN편" loading="lazy" frameborder="0" allow="autoplay; encrypted-media" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
               <div class="phone-card__top">
                 <span class="phone-card__avatar">F</span>
                 <div class="phone-card__id"><strong>FRUSH STUDIO</strong><span>브랜드 필름</span></div>
@@ -67,9 +65,7 @@
               </div>
             </div>
             <div class="phone-card">
-              <video class="phone-card__media" autoplay muted loop playsinline poster="Image_Storage/프러쉬_썸네일.png">
-                <source src="Videos/나홀로복싱 레퍼런스_업로드용.mp4" type="video/mp4">
-              </video>
+              <iframe class="phone-card__media" src="https://www.youtube.com/embed/3LcmIysyyKs?autoplay=1&amp;mute=1&amp;loop=1&amp;playlist=3LcmIysyyKs&amp;controls=0&amp;modestbranding=1&amp;playsinline=1&amp;rel=0" title="세종기프트 · 왕과 사는 부채, 허경환편" loading="lazy" frameborder="0" allow="autoplay; encrypted-media" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
               <div class="phone-card__top">
                 <span class="phone-card__avatar">F</span>
                 <div class="phone-card__id"><strong>FRUSH STUDIO</strong><span>시네마틱 쇼츠</span></div>


### PR DESCRIPTION
- vertical: phone previews now autoplay COCX 부산 / 왕과 사는 부채(허경환) via muted looped YouTube iframes
- ads: feature = 돌핀 30초, thumbs = 후참잘 / 탈취제 / 신라면, all opening the YouTube modal; thumbs converted from anchors to buttons (+reset)
- others: showcase carousel slides = 라이프 타임 → PROMPT → 안재욱(상하이) → PPL; setupShowcaseCarousel now supports youtubeUrl slides


Claude-Session: https://claude.ai/code/session_0192sPqBfb7igpq8Uh9RDHdp