### PR TITLE
Fix others copy, mobile phone-duo, and hero thumbnails

### DIFF
--- a/others.html
+++ b/others.html
@@ -30,8 +30,8 @@
         <div class="subpage-hero-shell grid items-center gap-10 p-6 sm:p-8 lg:grid-cols-[0.95fr_1.05fr] lg:p-12">
           <div class="reveal" data-reveal>
             <p class="text-sm font-semibold uppercase tracking-[0.32em] text-brand-main">Brand Film & More</p>
-            <h1 class="subhero-headline mt-5">브랜드의 분위기와 정보를<br><span class="text-brand-main">영상 언어</span>로 정리합니다.</h1>
-            <p class="mt-6 max-w-xl text-base leading-8 text-white/70 sm:text-lg">행사, 제품, 기술 소개, 인터뷰 영상은 전달해야 할 내용과 현장감이 분명해야 합니다. 프러쉬는 메시지 구조를 먼저 잡고 브랜드가 원하는 무드와 정보 밀도를 화면에 담습니다.</p>
+            <h1 class="subhero-headline mt-5">고객사의 분위기와 정보를<br><span class="text-brand-main">영상 언어</span>로 정리합니다.</h1>
+            <p class="mt-6 max-w-xl text-base leading-8 text-white/70 sm:text-lg">행사, 제품, 기술 소개, 인터뷰 영상은 전달해야 할 내용과 현장감이 분명해야 합니다. 프러쉬는 메시지 구조를 먼저 잡고 고객사가 원하는 무드와 정보 밀도를 화면에 담습니다.</p>
             <div class="tag-row mt-8">
               <span class="tag-chip"><i class="fas fa-calendar-day"></i>행사 영상</span>
               <span class="tag-chip"><i class="fas fa-box-open"></i>제품 소개</span>
@@ -39,7 +39,7 @@
               <span class="tag-chip"><i class="fas fa-user"></i>인터뷰 영상</span>
             </div>
             <div class="hero-cta-row mt-9">
-              <a href="https://open.kakao.com/me/frush" target="_blank" rel="noreferrer" class="hero-cta-button gap-2 bg-brand-main text-base font-semibold text-white shadow-glow transition hover:bg-brand-dark">브랜드 영상 문의하기 <i class="fas fa-chevron-right text-xs"></i></a>
+              <a href="https://open.kakao.com/me/frush" target="_blank" rel="noreferrer" class="hero-cta-button gap-2 bg-brand-main text-base font-semibold text-white shadow-glow transition hover:bg-brand-dark">다용도 영상 문의하기 <i class="fas fa-chevron-right text-xs"></i></a>
               <a href="#portfolio" class="hero-cta-button gap-2 border border-white/15 bg-white/5 text-base font-semibold text-white transition hover:bg-white/10">작업 사례 보기 <i class="fas fa-chevron-right text-xs"></i></a>
             </div>
           </div>

--- a/scripts/site.js
+++ b/scripts/site.js
@@ -794,7 +794,10 @@ window.FrushSite = (() => {
     }
     return {
       hi: getYoutubeThumb(work.youtubeUrl, 'maxresdefault'),
-      lo: getYoutubeThumb(work.youtubeUrl, 'mqdefault')
+      // hqdefault always exists (unlike maxres for brand-new uploads), so it is
+      // a reliable, reasonably sharp fallback — same source the work cards use.
+      lo: getYoutubeThumb(work.youtubeUrl, 'hqdefault'),
+      vertical: /\/shorts\//.test(work.youtubeUrl || '')
     };
   }
 
@@ -1167,6 +1170,27 @@ window.FrushSite = (() => {
     return selection;
   }
 
+  // Load the high-res thumbnail, falling back when it is missing. For very
+  // recent uploads YouTube serves a 120x90 grey placeholder for maxresdefault
+  // with a 200 status (so onerror never fires) — detect that tiny size and
+  // swap to the always-present fallback so no blank card appears.
+  function loadHeroThumb(img, hi, lo) {
+    if (!img) return;
+    const useFallback = () => {
+      if (img.getAttribute('src') !== lo) {
+        img.onerror = null;
+        img.src = lo;
+      }
+    };
+    img.onerror = useFallback;
+    img.onload = () => {
+      if (img.naturalWidth > 0 && img.naturalWidth <= 121 && /maxresdefault/.test(img.src)) {
+        useFallback();
+      }
+    };
+    img.src = hi;
+  }
+
   function setupStackedPanels() {
     const stage = document.getElementById('stacked-panels-scene');
     const container = document.getElementById('stacked-panels-container');
@@ -1183,11 +1207,13 @@ window.FrushSite = (() => {
       const panel = document.createElement('div');
       panel.className = 'stacked-panel';
       const thumb = panelImages[index % panelImages.length];
+      const portraitClass = thumb.vertical ? ' stacked-panel-image--portrait' : '';
       panel.innerHTML = `
-        <img class="stacked-panel-image" src="${thumb.hi}" onerror="this.onerror=null;this.src='${thumb.lo}'" alt="" loading="lazy">
+        <img class="stacked-panel-image${portraitClass}" alt="" loading="lazy">
         <div class="stacked-panel-vignette"></div>
         <div class="stacked-panel-border"></div>
       `;
+      loadHeroThumb(panel.querySelector('.stacked-panel-image'), thumb.hi, thumb.lo);
       container.appendChild(panel);
       return { panel, index };
     });

--- a/styles/site.css
+++ b/styles/site.css
@@ -245,7 +245,14 @@ body {
   width: 100%;
   object-fit: cover;
   object-position: center;
-  transform: scale(1.08);
+  transform: scale(1.02);
+}
+
+/* Vertical (Shorts) thumbnails are a 9:16 frame inside a 16:9 image, so they
+   carry black side bars. Zoom just enough to crop the bars out — maxres has
+   plenty of resolution, so this stays sharp. */
+.stacked-panel-image--portrait {
+  transform: scale(1.32);
 }
 
 .stacked-panel-gradient {
@@ -1546,6 +1553,14 @@ body {
   }
   .phone-card--lift {
     transform: none;
+  }
+  /* Stack the two phone previews so each is full-width and large enough
+     that the social UI overlays don't swallow the video on mobile. */
+  .phone-duo {
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+    max-width: 22rem;
+    margin-inline: auto;
   }
 }
 


### PR DESCRIPTION
- others hero: 브랜드→고객사, CTA → 다용도 영상 문의하기
- vertical: stack the two phone previews into one column on mobile so each is large enough that the overlays don't cover the video
- hero arch: fall back maxresdefault→hqdefault and detect YouTube's 120px grey placeholder (served 200 for brand-new uploads) so no blank card appears on the main page while category pages already use hqdefault
- zoom only vertical Shorts panels (scale 1.32) to crop their side bars; landscape panels stay un-zoomed to keep framing/quality


Claude-Session: https://claude.ai/code/session_0192sPqBfb7igpq8Uh9RDHdp