### PR TITLE
Fix mobile phone-duo collapse and hero blank/letterbox cards

### DIFF
--- a/scripts/site.js
+++ b/scripts/site.js
@@ -1176,19 +1176,17 @@ window.FrushSite = (() => {
   // swap to the always-present fallback so no blank card appears.
   function loadHeroThumb(img, hi, lo) {
     if (!img) return;
-    const useFallback = () => {
-      if (img.getAttribute('src') !== lo) {
-        img.onerror = null;
-        img.src = lo;
-      }
+    // Show hqdefault immediately: it always exists, so no card is ever blank.
+    img.src = lo;
+    if (!hi || hi === lo) return;
+    // Then upgrade to maxresdefault only if it is a real image. Missing maxres
+    // 404s (probe error) or returns a tiny grey placeholder (naturalWidth ~120)
+    // for brand-new uploads — in both cases we keep hqdefault.
+    const probe = new Image();
+    probe.onload = () => {
+      if (probe.naturalWidth > 320) img.src = hi;
     };
-    img.onerror = useFallback;
-    img.onload = () => {
-      if (img.naturalWidth > 0 && img.naturalWidth <= 121 && /maxresdefault/.test(img.src)) {
-        useFallback();
-      }
-    };
-    img.src = hi;
+    probe.src = hi;
   }
 
   function setupStackedPanels() {
@@ -1207,9 +1205,8 @@ window.FrushSite = (() => {
       const panel = document.createElement('div');
       panel.className = 'stacked-panel';
       const thumb = panelImages[index % panelImages.length];
-      const portraitClass = thumb.vertical ? ' stacked-panel-image--portrait' : '';
       panel.innerHTML = `
-        <img class="stacked-panel-image${portraitClass}" alt="" loading="lazy">
+        <img class="stacked-panel-image" alt="" loading="lazy">
         <div class="stacked-panel-vignette"></div>
         <div class="stacked-panel-border"></div>
       `;

--- a/styles/site.css
+++ b/styles/site.css
@@ -245,14 +245,10 @@ body {
   width: 100%;
   object-fit: cover;
   object-position: center;
-  transform: scale(1.02);
-}
-
-/* Vertical (Shorts) thumbnails are a 9:16 frame inside a 16:9 image, so they
-   carry black side bars. Zoom just enough to crop the bars out — maxres has
-   plenty of resolution, so this stays sharp. */
-.stacked-panel-image--portrait {
-  transform: scale(1.32);
+  /* Crop the letterbox: hqdefault is 4:3 (black bars on 16:9 and Shorts
+     alike) and maxres is 16:9 (side bars on Shorts). A uniform zoom clears
+     the bars whichever source ends up loading. */
+  transform: scale(1.34);
 }
 
 .stacked-panel-gradient {
@@ -1554,13 +1550,14 @@ body {
   .phone-card--lift {
     transform: none;
   }
-  /* Stack the two phone previews so each is full-width and large enough
-     that the social UI overlays don't swallow the video on mobile. */
+  /* Stack the two phone previews into one full-width column so each is large
+     enough that the social UI overlays don't swallow the video on mobile.
+     (No max-width + margin:auto here: auto margins make the grid item
+     shrink-to-fit, and phone-card has no intrinsic width — aspect-ratio only
+     derives height from width — so it would collapse to 0 and disappear.) */
   .phone-duo {
     grid-template-columns: 1fr;
     gap: 1.5rem;
-    max-width: 22rem;
-    margin-inline: auto;
   }
 }
 


### PR DESCRIPTION
- Mobile vertical previews vanished because margin-inline:auto made the grid item shrink-to-fit, and phone-card has no intrinsic width (aspect-ratio only derives height) so it collapsed to 0. Drop the auto margin/max-width: full-width single column.
- Hero arch: load hqdefault first (always present → never a blank card), then upgrade to maxresdefault only when it's a real image. Uniform scale(1.34) crops the 4:3 letterbox bars for every panel.


Claude-Session: https://claude.ai/code/session_0192sPqBfb7igpq8Uh9RDHdp