### PR TITLE
Compact partner cards and update teams copy

### DIFF
--- a/scripts/site.js
+++ b/scripts/site.js
@@ -1172,8 +1172,8 @@ window.FrushSite = (() => {
             <div class="flex items-start justify-between gap-4">
               <div>
                 <p class="text-sm font-semibold uppercase tracking-[0.28em] text-brand-main">Teams</p>
-                <h2 class="mt-3 text-3xl font-semibold text-brand-text">함께하는 <span class="text-brand-main">두 팀</span></h2>
-                <p class="mt-3 text-sm leading-6 text-slate-500">프러쉬 스튜디오 안에서 프러쉬 팀과 BMH 팀이 협력해 기획부터 제작까지 함께합니다.</p>
+                <h2 class="mt-3 text-3xl font-semibold text-brand-text">함께하는 <span class="text-brand-main">사람들</span></h2>
+                <p class="mt-3 text-sm leading-6 text-slate-500">프러쉬 스튜디오 안에 소속된 여러 팀이 유기적으로 협력해 기획부터 제작까지 완성합니다.</p>
               </div>
               <div class="hidden h-14 w-14 shrink-0 items-center justify-center rounded-2xl bg-brand-dark text-brand-light shadow-soft md:flex">
                 <i class="fas fa-users text-xl"></i>

--- a/styles/site.css
+++ b/styles/site.css
@@ -792,13 +792,13 @@ body {
 .partner-card {
   position: relative;
   display: flex;
-  height: 7rem;
-  width: 12rem;
+  height: 5.25rem;
+  width: 9.5rem;
   flex-shrink: 0;
   align-items: center;
   justify-content: center;
   overflow: hidden;
-  border-radius: 1.5rem;
+  border-radius: 1.15rem;
   border: 1px solid rgba(226, 232, 240, 0.72);
   /* Opaque background (no backdrop-filter): a moving backdrop-filter shimmers
      along the card edges while the marquee scrolls on mobile (iOS Safari). */
@@ -808,19 +808,19 @@ body {
 
 .partner-card__inner {
   display: flex;
-  height: calc(100% - 1rem);
-  width: calc(100% - 1rem);
+  height: calc(100% - 0.6rem);
+  width: calc(100% - 0.6rem);
   align-items: center;
   justify-content: center;
-  border-radius: 1.15rem;
+  border-radius: 0.95rem;
   background: rgba(255, 255, 255, 0.9);
   box-shadow: inset 0 0 0 1px rgba(226, 232, 240, 0.5);
 }
 
 .partner-card img {
-  max-height: 64%;
+  max-height: 66%;
   width: auto;
-  max-width: 74%;
+  max-width: 82%;
   object-fit: contain;
 }
 


### PR DESCRIPTION
- Shrink partner cards (5.25rem x 9.5rem) with tighter inner padding and larger logo bounds so the small source logos fit proportionally rather than floating in oversized boxes
- Teams card: 함께하는 두 팀 → 함께하는 사람들, with updated subtitle


Claude-Session: https://claude.ai/code/session_0192sPqBfb7igpq8Uh9RDHdp