### PR TITLE
Point all Frush KakaoTalk links to the channel URL

### DIFF
--- a/ads.html
+++ b/ads.html
@@ -33,7 +33,7 @@
             <h1 class="subhero-headline mt-5">광고의 목적과<br>매체에 맞춰<br>한 화면의 <span class="text-brand-main">설득력</span>을 만듭니다.</h1>
             <p class="mt-6 max-w-xl text-base leading-8 text-white/70 sm:text-lg">프러쉬 스튜디오는 TVC, 유튜브 광고, 매장 광고, 옥외 광고까지 집행 환경에 맞춰 메시지와 화면 밀도를 설계합니다. 브랜드 톤은 지키고 전달력은 높이는 광고 영상을 제작합니다.</p>
             <div class="hero-cta-row mt-9">
-              <a href="https://open.kakao.com/me/frush" target="_blank" rel="noreferrer" class="hero-cta-button gap-2 bg-brand-main text-base font-semibold text-white shadow-glow transition hover:bg-brand-dark">광고 영상 문의하기 <i class="fas fa-chevron-right text-xs"></i></a>
+              <a href="https://pf.kakao.com/_zHnVX" target="_blank" rel="noreferrer" class="hero-cta-button gap-2 bg-brand-main text-base font-semibold text-white shadow-glow transition hover:bg-brand-dark">광고 영상 문의하기 <i class="fas fa-chevron-right text-xs"></i></a>
               <a href="#portfolio" class="hero-cta-button gap-2 border border-white/15 bg-white/5 text-base font-semibold text-white transition hover:bg-white/10">광고 포트폴리오 보기 <i class="fas fa-chevron-right text-xs"></i></a>
             </div>
             <p class="hero-note mt-8"><i class="fas fa-comment-dots"></i>목표와 매체만 알려주셔도 적합한 영상 방향을 제안드립니다.</p>

--- a/contact.html
+++ b/contact.html
@@ -34,10 +34,10 @@
               <h1 class="mt-4 text-4xl font-bold leading-[1.12] text-white sm:text-5xl lg:text-6xl">막막한 기획도<br><span class="text-transparent bg-clip-text bg-gradient-to-r from-emerald-400 to-teal-300">실행 가능한</span> 장면으로<br>빠르게 연결합니다.</h1>
               <p class="mt-6 max-w-2xl text-base leading-8 text-white/72 sm:text-lg">프러쉬 스튜디오는 프로젝트의 목적과 우선순위를 함께 정리하고,<br class="hidden sm:block"> 브랜드에 맞는 영상 포맷과 제작 방향을 빠르게 제안합니다.<br class="hidden sm:block"> 상담 단계부터 결과물의 쓰임까지 고려합니다.</p>
               <div class="hero-cta-row mt-10">
-                <a href="https://open.kakao.com/me/frush" target="_blank" rel="noreferrer" class="hero-cta-button gap-3 bg-brand-main text-base font-semibold text-white shadow-glow transition hover:bg-brand-dark">
+                <a href="https://pf.kakao.com/_zHnVX" target="_blank" rel="noreferrer" class="hero-cta-button gap-3 bg-brand-main text-base font-semibold text-white shadow-glow transition hover:bg-brand-dark">
                   문의하기 <i class="fas fa-arrow-up-right-from-square text-sm"></i>
                 </a>
-                <a href="https://open.kakao.com/me/frush" target="_blank" rel="noreferrer" class="hero-cta-button gap-2 border border-white/15 bg-white/5 text-base font-semibold text-white transition hover:bg-white/10">
+                <a href="https://pf.kakao.com/_zHnVX" target="_blank" rel="noreferrer" class="hero-cta-button gap-2 border border-white/15 bg-white/5 text-base font-semibold text-white transition hover:bg-white/10">
                   오픈카톡 상담 <i class="far fa-comment-dots text-sm"></i>
                 </a>
               </div>

--- a/others.html
+++ b/others.html
@@ -39,7 +39,7 @@
               <span class="tag-chip"><i class="fas fa-user"></i>인터뷰 영상</span>
             </div>
             <div class="hero-cta-row mt-9">
-              <a href="https://open.kakao.com/me/frush" target="_blank" rel="noreferrer" class="hero-cta-button gap-2 bg-brand-main text-base font-semibold text-white shadow-glow transition hover:bg-brand-dark">다용도 영상 문의하기 <i class="fas fa-chevron-right text-xs"></i></a>
+              <a href="https://pf.kakao.com/_zHnVX" target="_blank" rel="noreferrer" class="hero-cta-button gap-2 bg-brand-main text-base font-semibold text-white shadow-glow transition hover:bg-brand-dark">다용도 영상 문의하기 <i class="fas fa-chevron-right text-xs"></i></a>
               <a href="#portfolio" class="hero-cta-button gap-2 border border-white/15 bg-white/5 text-base font-semibold text-white transition hover:bg-white/10">작업 사례 보기 <i class="fas fa-chevron-right text-xs"></i></a>
             </div>
           </div>

--- a/scripts/site.js
+++ b/scripts/site.js
@@ -1,5 +1,5 @@
 window.FrushSite = (() => {
-  const KAKAO_URL = 'https://open.kakao.com/me/frush';
+  const KAKAO_URL = 'https://pf.kakao.com/_zHnVX';
   const TEAM_PHOTO_URL = 'Images/5인 단체사진_프러쉬.png';
   const PANEL_COUNT = 18;
   // Hero arch card images are built at render time from the latest works

--- a/vertical.html
+++ b/vertical.html
@@ -33,7 +33,7 @@
             <h1 class="subhero-headline mt-5">첫 1초에 멈추게 만들고<br><span class="text-brand-main">끝까지 보게</span> 설계합니다.</h1>
             <p class="mt-6 max-w-xl text-base leading-8 text-white/70 sm:text-lg">릴스, 쇼츠, 틱톡처럼 빠르게 소비되는 화면에서는 첫 장면의 후킹과 리듬이 성과를 가릅니다. 프러쉬는 브랜드 메시지를 짧은 흐름 안에 자연스럽게 심어 스크롤을 멈추는 세로형 영상을 제작합니다.</p>
             <div class="hero-cta-row mt-9">
-              <a href="https://open.kakao.com/me/frush" target="_blank" rel="noreferrer" class="hero-cta-button gap-2 bg-brand-main text-base font-semibold text-white shadow-glow transition hover:bg-brand-dark">세로형 영상 문의하기 <i class="fas fa-chevron-right text-xs"></i></a>
+              <a href="https://pf.kakao.com/_zHnVX" target="_blank" rel="noreferrer" class="hero-cta-button gap-2 bg-brand-main text-base font-semibold text-white shadow-glow transition hover:bg-brand-dark">세로형 영상 문의하기 <i class="fas fa-chevron-right text-xs"></i></a>
               <a href="#portfolio" class="hero-cta-button gap-2 border border-white/15 bg-white/5 text-base font-semibold text-white transition hover:bg-white/10">세로형 포트폴리오 보기 <i class="fas fa-chevron-right text-xs"></i></a>
             </div>
             <div class="spec-grid mt-10">


### PR DESCRIPTION
Replace every open.kakao.com/me/frush link with
https://pf.kakao.com/_zHnVX — the KAKAO_URL constant (header/footer) and the hardcoded hero CTAs in vertical/ads/others/contact.


Claude-Session: https://claude.ai/code/session_0192sPqBfb7igpq8Uh9RDHdp